### PR TITLE
fixes (#35)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,11 @@ ibv_test_SOURCES +=      tests/peer-direct/smoke.cc
 endif
 
 if TAG_MATCHING
+if TAG_MATCHING_V0_2
 ibv_test_SOURCES +=	 tests/tag-matching/smoke.cc
+else
+ibv_test_SOURCES +=	 tests/tag-matching/smoke_old.cc
+endif
 endif
 
 ibv_test_SOURCES +=      tests/odp/smoke.cc

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,8 @@ fi
 
 AC_CHECK_HEADERS([infiniband/verbs_exp.h])
 
+AC_CHECK_HEADERS([infiniband/arch.h])
+
 AC_CHECK_HEADER([infiniband/peer_ops.h], [
     peerdirect=1
     AC_ARG_WITH([peer],
@@ -104,6 +106,10 @@ AC_CHECK_DECL([IBV_SRQT_TAG_MATCHING], [tag_matching=1], [], [
 #include <infiniband/verbs.h>
 ])
 AM_CONDITIONAL([TAG_MATCHING], [test x$tag_matching = x1])
+AC_CHECK_DECLS([ibv_post_srq_ops], [tag_matching_2=1], [], [
+#include <infiniband/verbs.h>
+])
+AM_CONDITIONAL([TAG_MATCHING_V0_2], [test x$tag_matching_2 = x1])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/include/verbs_test.h
+++ b/include/verbs_test.h
@@ -30,7 +30,6 @@
 #define _IBVERBS_VERBS_TEST_
 #include "common.h"
 #include <infiniband/verbs.h>
-#include <infiniband/arch.h>
 
 /**
  * Base class for ibverbs test fixtures.

--- a/tests/basic/smoke.cc
+++ b/tests/basic/smoke.cc
@@ -114,7 +114,8 @@ TYPED_TEST(base_test, t0) {
 	CHK_SUT(basic);
 	EXEC(recv(0, SZ));
 	EXEC(send(0, SZ));
-	EXEC(cq.poll(2));
+	EXEC(cq.poll(1));
+	EXEC(cq.poll(1));
 	EXEC(dst_mr.check());
 }
 
@@ -123,9 +124,11 @@ TYPED_TEST(base_test, t1) {
 	EXEC(recv(0, SZ/2));
 	EXEC(recv(SZ/2, SZ/2));
 	EXEC(send(0, SZ/2));
-	EXEC(cq.poll(2));
+	EXEC(cq.poll(1));
+	EXEC(cq.poll(1));
 	EXEC(send(SZ/2, SZ/2));
-	EXEC(cq.poll(2));
+	EXEC(cq.poll(1));
+	EXEC(cq.poll(1));
 	EXEC(dst_mr.check());
 }
 

--- a/tests/flow_tag/smoke.cc
+++ b/tests/flow_tag/smoke.cc
@@ -249,7 +249,7 @@ struct ibvt_raw_qp : public ibvt_qp {
 
 	void set_up_flow_rules(
                 struct ibv_flow_attr **flow_rules) {
-
+#ifdef HAVE_VXLAN
         struct ibv_flow_spec* spec_info;
         struct ibv_flow_attr* attr_info;
 	struct ibv_flow_spec_action_tag* flow_tag_ptr;
@@ -335,7 +335,7 @@ struct ibvt_raw_qp : public ibvt_qp {
                         flow_tag_ptr->size = sizeof(struct ibv_flow_spec_action_tag);
                         flow_tag_ptr->tag_id = 507;
         }
-
+	#endif
 }
 	
 	void send_raw_packet(void* buf,int match)

--- a/tests/general/init.cc
+++ b/tests/general/init.cc
@@ -45,6 +45,9 @@ TEST(tc_ibv_get_device_list, ti_1) {
 	ibv_free_device_list(dev_list);
 }
 
+#ifdef HAVE_INFINIBAND_ARCH_H
+#include <infiniband/arch.h>
+
 /* ibv_get_device_name: [TI.1] Correct */
 TEST(tc_ibv_get_device_name, ti_1) {
 
@@ -91,3 +94,5 @@ TEST(tc_ibv_open_device, ti_1) {
 	}
 	ibv_free_device_list(dev_list);
 }
+
+#endif

--- a/tests/odp/smoke.cc
+++ b/tests/odp/smoke.cc
@@ -78,7 +78,7 @@ struct ibvt_mr_pf : public ibvt_mr {
 };
 #endif
 
-#ifdef HAVE_DECL_IBV_ACCESS_HUGETLB
+#if HAVE_DECL_IBV_ACCESS_HUGETLB
 struct ibvt_mr_hp : public ibvt_mr {
 	ibvt_mr_hp(ibvt_env &e, ibvt_pd &p, size_t s, intptr_t a, long af) :
 		ibvt_mr(e, p, s, a, af | IBV_ACCESS_HUGETLB) {}
@@ -220,7 +220,8 @@ struct odp_prefetch : public odp_mem {
 };
 #endif
 
-#ifdef HAVE_DECL_IBV_ACCESS_HUGETLB
+
+#if HAVE_DECL_IBV_ACCESS_HUGETLB
 struct odp_hugetlb : public odp_mem {
 	odp_hugetlb(odp_side &s, odp_side &d) : odp_mem(s, d) {}
 
@@ -317,6 +318,31 @@ struct odp_rdma_write : public odp_base {
 	}
 };
 
+struct odp_rdma_write_1_signal : public odp_base {
+	odp_rdma_write_1_signal():
+		odp_base(0, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE) {}
+
+	virtual void test(unsigned long src, unsigned long dst, size_t len, int count = 1) {
+		EXEC(mem().reg(src, dst, len));
+		EXEC(mem().src().fill());
+		EXEC(mem().dst().init());
+		enum ibv_send_flags f = IBV_SEND_INLINE;
+
+		EXEC(check_stats(2, 0));
+		for (int i = 0; i < count; i++) {
+			if (i == count-1)
+				f = (enum ibv_send_flags)(IBV_SEND_INLINE | IBV_SEND_SIGNALED);
+			EXEC(src.qp.rdma(mem().src().sge(len/count*i, len/count),
+						mem().dst().sge(len/count*i, len/count),
+						IBV_WR_RDMA_WRITE, f));
+		}
+		EXEC(src.cq.poll(1));
+		EXEC(check_stats(2, len / 0x1000 * 2));
+		EXEC(mem().dst().check());
+		EXEC(mem().unreg());
+	}
+};
+
 template <typename T1, typename T2>
 struct types {
 	typedef T1 MEM;
@@ -346,7 +372,8 @@ typedef testing::Types<
 	types<odp_implicit, odp_send>,
 	types<odp_implicit, odp_rdma_read>,
 	types<odp_implicit, odp_rdma_write>,
-#ifdef HAVE_DECL_IBV_ACCESS_HUGETLB
+	//types<odp_implicit, odp_rdma_write_1_signal>,
+#if HAVE_DECL_IBV_ACCESS_HUGETLB
 	types<odp_hugetlb, odp_send>,
 	types<odp_hugetlb, odp_rdma_read>,
 	types<odp_hugetlb, odp_rdma_write>,
@@ -356,19 +383,31 @@ typedef testing::Types<
 	types<odp_off, odp_rdma_write>
 > odp_env_list;
 
+#ifdef __x86_64__
+
+#define PAGE 0x1000
+#define UP (1ULL<<47)
+
+#elif (__ppc64__|__PPC64__)
+
+#define PAGE 0x10000
+#define UP (1ULL<<46)
+
+#endif
+
 TYPED_TEST_CASE(odp, odp_env_list);
 
 TYPED_TEST(odp, t0_crossbound) {
 	CHK_SUT(odp);
-	EXEC(test((1ULL<<(32+1))-0x1000,
-		  (1ULL<<(32+2))-0x1000,
+	EXEC(test((1ULL<<(32+1))-PAGE,
+		  (1ULL<<(32+2))-PAGE,
 		  0x2000));
 }
 
 TYPED_TEST(odp, t1_upper) {
 	CHK_SUT(odp);
-	EXEC(test((1ULL<<47) - 0x10000 * 1,
-		  (1ULL<<47) - 0x10000 * 2,
+	EXEC(test(UP - 0x10000 * 1,
+		  UP - 0x10000 * 2,
 		  0x2000));
 }
 
@@ -376,28 +415,36 @@ TYPED_TEST(odp, t2_sequence) {
 	CHK_SUT(odp);
 	unsigned long p = 0x2000000000;
 	for (int i = 0; i < 20; i++) {
-		EXEC(test(p, p+0x1000, 0x1000));
-		p += 0x2000;
+		EXEC(test(p, p+PAGE, PAGE));
+		p += PAGE * 2;
 	}
 }
 
-TYPED_TEST(odp, t25_6M) {
+TYPED_TEST(odp, t3_1b) {
+	CHK_SUT(odp);
+	unsigned long p = 0x2000000000;
+	EXEC(test(p, p+PAGE, PAGE, PAGE/0x10));
+}
+
+TYPED_TEST(odp, t4_6M) {
 	CHK_SUT(odp);
 	EXEC(test(0,0,0x600000,0x10));
 }
 
 
-TYPED_TEST(odp, t3_3G) {
+TYPED_TEST(odp, t5_3G) {
 	CHK_SUT(odp);
 	EXEC(test(0, 0,
 		  0xe0000000,
 		  0x10));
 }
 
+#ifdef HUGE_AMOUNT_OF_MEMORY
 TYPED_TEST(odp, t4_16Gplus) {
 	CHK_SUT(odp);
 	EXEC(test(0, 0,
 		  0x400000100,
 		  0x100));
 }
+#endif
 

--- a/tests/tag-matching/smoke_old.cc
+++ b/tests/tag-matching/smoke_old.cc
@@ -87,6 +87,9 @@
 #define IBV_WC_TM_NOOP IBV_EXP_WC_TM_NOOP
 #endif
 
+//#define SZ 0x2000
+//#define SZ 0x80
+
 #define DEF_ibv_wc_opcode \
 	DEF_ENUM_ELEM(IBV_WC_SEND) \
 	DEF_ENUM_ELEM(IBV_WC_RDMA_WRITE) \
@@ -98,18 +101,17 @@
 	DEF_ENUM_ELEM(IBV_WC_RECV) \
 	DEF_ENUM_ELEM(IBV_WC_RECV_RDMA_WITH_IMM) \
 	DEF_ENUM_ELEM(IBV_WC_TM_RECV) \
-	DEF_ENUM_ELEM(IBV_WC_TM_NO_TAG) \
-	DEF_ENUM_ELEM(IBV_WC_TM_APPEND) \
-	DEF_ENUM_ELEM(IBV_WC_TM_REMOVE) \
-	DEF_ENUM_ELEM(IBV_WC_TM_NOOP)
-#define OLD_TM_ARCH_ibv_wc_opcode \
 	DEF_ENUM_ELEM(IBV_WC_TM_UNEXP) \
 	DEF_ENUM_ELEM(IBV_WC_TM_CONSUMED_EAGER) \
 	DEF_ENUM_ELEM(IBV_WC_TM_CONSUMED_RNDV) \
 	DEF_ENUM_ELEM(IBV_WC_TM_CONSUMED_SW_RNDV) \
 	DEF_ENUM_ELEM(IBV_WC_TM_RECV_CONSUMED_EAGER) \
 	DEF_ENUM_ELEM(IBV_WC_TM_RECV_CONSUMED_RNDV) \
-	DEF_ENUM_ELEM(IBV_WC_TM_RECV_CONSUMED_SW_RNDV)
+	DEF_ENUM_ELEM(IBV_WC_TM_RECV_CONSUMED_SW_RNDV) \
+	DEF_ENUM_ELEM(IBV_WC_TM_NO_TAG) \
+	DEF_ENUM_ELEM(IBV_WC_TM_APPEND) \
+	DEF_ENUM_ELEM(IBV_WC_TM_REMOVE) \
+	DEF_ENUM_ELEM(IBV_WC_TM_NOOP) \
 
 #define DEF_ENUM_ELEM DEF_ENUM_ELEM_TO_STR
 
@@ -117,22 +119,14 @@ DEF_ENUM_TO_STR_BEGIN(ibv_wc_opcode)
 DEF_ibv_wc_opcode
 DEF_ENUM_TO_STR_END
 
-//#define max(a, b) ((a) > (b) ? (a) : (b))
-
-struct tag_matching_base : public ibvt_env {
-	int phase_cnt;
-};
-
 struct ibvt_srq : public ibvt_obj {
 	struct ibv_srq *srq;
 
 	ibvt_pd &pd;
 	ibvt_cq &cq;
 
-	tag_matching_base &tm;
-
-	ibvt_srq(tag_matching_base &e, ibvt_pd &p, ibvt_cq &c) :
-		 ibvt_obj(e), srq(NULL), pd(p), cq(c), tm(e) {}
+	ibvt_srq(ibvt_env &e, ibvt_pd &p, ibvt_cq &c) :
+		 ibvt_obj(e), srq(NULL), pd(p), cq(c) {}
 
 	~ibvt_srq() {
 		FREE(ibv_destroy_srq, srq);
@@ -152,15 +146,14 @@ struct ibvt_srq : public ibvt_obj {
 		attr.srq_type = IBV_SRQT_TAG_MATCHING;
 		attr.pd = pd.pd;
 		attr.cq = cq.cq;
-		attr.tm_cap.max_tm_ops = 10;
-		attr.tm_cap.max_num_tags = 64;
+		attr.tm_list_size = 64;
 		attr.attr.max_wr  = 128;
 		attr.attr.max_sge = 1;
 
 		SET(srq, ibv_create_srq_ex(pd.ctx.ctx, &attr));
 	}
 
-	virtual void unexp(ibvt_mr &mr, int start, int length) {
+	virtual void recv(ibvt_mr &mr, int start, int length) {
 		struct ibv_recv_wr wr;
 		struct ibv_sge sge = mr.sge(start, length);
 		struct ibv_recv_wr *bad_wr = NULL;
@@ -172,50 +165,11 @@ struct ibvt_srq : public ibvt_obj {
 		wr.num_sge = 1;
 		DO(ibv_post_srq_recv(srq, &wr, &bad_wr));
 	}
-
-	virtual void append(ibvt_mr &mr, int start, int length,
-			    uint64_t tag, int *idx)
-	{
-		struct ibv_sge sge = mr.sge(start, length);
-		struct ibv_ops_wr wr;
-		struct ibv_ops_wr *bad_wr = NULL;
-
-		memset(&wr, 0, sizeof(wr));
-		wr.sg_list = &sge;
-		wr.num_sge = 1;
-		wr.flags = IBV_SEND_SIGNALED;
-		wr.opcode = IBV_WR_TAG_APPEND;
-
-		wr.tm.tag.tag = tag;
-		wr.tm.mask.tag	= 0xffffffffffffffff;
-		wr.tm.unexpected_cnt = tm.phase_cnt;
-
-		DO(ibv_post_srq_ops(srq, &wr, &bad_wr));
-
-		if (idx)
-			*idx = wr.tm.handle;
-	}
-
-	virtual void remove(int idx)
-	{
-		struct ibv_ops_wr wr;
-		struct ibv_ops_wr *bad_wr = NULL;
-
-		memset(&wr, 0, sizeof(wr));
-		wr.flags = IBV_SEND_SIGNALED;
-		wr.opcode = IBV_WR_TAG_REMOVE;
-		wr.tm.handle = idx;
-
-		DO(ibv_post_srq_ops(srq, &wr, &bad_wr));
-	}
-
 };
 
 struct ibvt_qp_tm : public ibvt_qp_rc {
-	ibvt_ctx &ctx;
-
-	ibvt_qp_tm(ibvt_env &e, ibvt_ctx &d, ibvt_pd &p, ibvt_cq &c) :
-		    ibvt_qp_rc(e, p, c), ctx(d) {}
+	ibvt_qp_tm(ibvt_env &e, ibvt_pd &p, ibvt_cq &c) :
+		    ibvt_qp_rc(e, p, c) {}
 
 	virtual void init_attr(struct ibv_qp_init_attr_ex &attr)
 	{
@@ -224,54 +178,43 @@ struct ibvt_qp_tm : public ibvt_qp_rc {
 	}
 
 	virtual void send(ibv_sge sge,
-			  uint64_t tag,
-			  enum ibv_tm_op op)
+			  uint64_t tag, enum ibv_wr_opcode op,
+			  int send_flags = 0)
 	{
 		struct ibv_send_wr wr;
 		struct ibv_send_wr *bad_wr = NULL;
-		struct ibv_tm_info tm;
-
-		memset(&tm, 0 ,sizeof(tm));
-		tm.op = op;
-		tm.tag.tag = tag;
-		ASSERT_GE(ibv_pack_tm_info(ctx.ctx, (void*)sge.addr, &tm), 1);
 
 		memset(&wr, 0, sizeof(wr));
-		wr.send_flags = IBV_SEND_SIGNALED;
-		wr.opcode = IBV_WR_SEND;
+		wr.send_flags = IBV_SEND_SIGNALED | send_flags;
+		wr.opcode = op;
 		wr.num_sge = 1;
 		wr.sg_list = &sge;
 		wr.wr_id = 0x12345;
 
+		wr.tm_match.match.bits_64  = tag;
+
 		DO(ibv_post_send(qp, &wr, &bad_wr));
 	}
 
-	virtual void rndv(ibv_sge sge, uint64_t tag)
+	virtual void rndv(ibv_sge sge, uint64_t tag, ibvt_mr &mr2)
 	{
 		struct ibv_send_wr wr;
 		struct ibv_send_wr *bad_wr = NULL;
-		ibvt_mr hdr(env, pd, 0x20);
-		struct ibv_sge sge_hdr;
-		struct ibv_tm_info tm;
-
-		hdr.init();
-
-		memset(&tm, 0 ,sizeof(tm));
-		tm.op = IBV_TM_OP_RNDV;
-		tm.tag.tag = tag;
-		tm.rndv.remote_mkey = sge.lkey;
-		tm.rndv.buffer_vaddr = sge.addr;
-		tm.rndv.buffer_len = sge.length;
-		ASSERT_GE(ibv_pack_tm_info(ctx.ctx, (void*)hdr.buff, &tm), 1);
-		//hdr.dump();
+		struct ibv_sge sge2;
 
 		memset(&wr, 0, sizeof(wr));
-		wr.send_flags = IBV_SEND_SIGNALED;
-		wr.opcode = IBV_WR_SEND;
-		wr.num_sge = 1;
-		sge_hdr = hdr.sge();
-		wr.sg_list = &sge_hdr;
+		wr.send_flags = IBV_SEND_SIGNALED | IBV_SEND_INLINE;
+		wr.opcode = IBV_WR_TAG_SEND_RNDV;
+		wr.tm_match.rndv.remote_mkey = sge.lkey;
+		wr.tm_match.rndv.buffer_vaddr = sge.addr;
+		wr.tm_match.rndv.buffer_len = sge.length;
+		if (mr2.buff) {
+			sge2 = mr2.sge();
+			wr.num_sge = 1;
+			wr.sg_list = &sge2;
+		}
 		wr.wr_id = 0x12345;
+		wr.tm_match.match.bits_64  = tag;
 
 		DO(ibv_post_send(qp, &wr, &bad_wr));
 	}
@@ -290,6 +233,40 @@ struct ibvt_qp_srq : public ibvt_qp_rc {
 		attr.srq = srq.srq;
 	}
 
+	virtual void append(ibvt_mr &mr, int start, int length,
+			    uint64_t tag, int *idx)
+	{
+		struct ibv_send_wr wr;
+		struct ibv_sge sge = mr.sge(start, length);
+		struct ibv_send_wr *bad_wr = NULL;
+
+		memset(&wr, 0, sizeof(wr));
+		wr.sg_list = &sge;
+		wr.num_sge = 1;
+		wr.send_flags = IBV_SEND_SIGNALED;
+		wr.opcode = IBV_WR_TAG_APPEND;
+
+		wr.tm_tag.match.bits_64 = tag;
+		wr.tm_tag.mask.bits_64	= 0xffffffffffffffff;
+
+		DO(ibv_post_send(qp, &wr, &bad_wr));
+
+		if (idx)
+			*idx = wr.tm_tag.tag_idx;
+	}
+
+	virtual void remove(int idx)
+	{
+		struct ibv_send_wr wr;
+		struct ibv_send_wr *bad_wr = NULL;
+
+		memset(&wr, 0, sizeof(wr));
+		wr.send_flags = IBV_SEND_SIGNALED;
+		wr.opcode = IBV_WR_TAG_REMOVE;
+		wr.tm_tag.tag_idx = idx;
+
+		DO(ibv_post_send(qp, &wr, &bad_wr));
+	}
 };
 
 struct ibvt_qp_rndv : public ibvt_qp_srq {
@@ -304,9 +281,7 @@ struct ibvt_qp_rndv : public ibvt_qp_srq {
 };
 
 struct ibvt_cq_tm : public ibvt_cq {
-	tag_matching_base &tm;
-
-	ibvt_cq_tm(tag_matching_base &e, ibvt_ctx &c) : ibvt_cq(e, c), tm(e) {}
+	ibvt_cq_tm(ibvt_env &e, ibvt_ctx &c) : ibvt_cq(e, c) {}
 
 	virtual void poll(int n) {
 		struct ibv_wc wc = {};
@@ -320,13 +295,13 @@ struct ibvt_cq_tm : public ibvt_cq {
 		}
 		ASSERT_GT(retries,0) << "errno: " << errno;
 
-		if (wc.opcode == IBV_WC_TM_RECV && !(wc.wc_flags & (IBV_WC_TM_MATCH | IBV_WC_TM_DATA_VALID)))
-			tm.phase_cnt ++;
-
-		VERBS_INFO("poll status %s(%d) opcode %s(%d) len %d flags %x lid %x wr_id %lx\n",
+		VERBS_INFO("poll status %s(%d) opcode %s(%d) len %d qp %x lid %x app_ctx %lx recv_id %x tag %lx wr_id %lx\n",
 				ibv_wc_status_str(wc.status), wc.status,
 				ibv_wc_opcode_str(wc.opcode), wc.opcode,
-				wc.byte_len, wc.wc_flags, wc.slid,
+				wc.byte_len, wc.qp_num, wc.slid,
+				wc.tm_data.app_ctx,
+				wc.tm_data.recv_id,
+				wc.tm_data.sender_tag,
 				wc.wr_id);
 		ASSERT_FALSE(wc.status) << ibv_wc_status_str(wc.status);
 		if (n && !wc.byte_len)
@@ -334,35 +309,40 @@ struct ibvt_cq_tm : public ibvt_cq {
 	}
 };
 
-struct tag_matching : public testing::TestWithParam<int>, public tag_matching_base {
+struct tag_matching : public testing::TestWithParam<int>, public ibvt_env {
 	struct ibvt_ctx ctx;
 	struct ibvt_pd pd;
 	struct ibvt_cq_tm srq_cq;
 	struct ibvt_srq srq;
+	struct ibvt_cq ctrl_cq;
+	struct ibvt_qp_srq ctrl_qp;
 	struct ibvt_cq send_cq;
 	struct ibvt_qp_tm send_qp;
 	struct ibvt_cq recv_cq;
 	struct ibvt_qp_rndv recv_qp;
-	struct ibvt_mr src_mr;
-	struct ibvt_mr dst_mr;
+	struct ibvt_mr_hdr src_mr;
+	struct ibvt_mr_hdr dst_mr;
 
 	tag_matching() :
 		ctx(*this, NULL),
 		pd(*this, ctx),
 		srq_cq(*this, ctx),
 		srq(*this, pd, srq_cq),
+		ctrl_cq(*this, ctx),
+		ctrl_qp(*this, pd, ctrl_cq, srq),
 		send_cq(*this, ctx),
-		send_qp(*this, ctx, pd, send_cq),
+		send_qp(*this, pd, send_cq),
 		recv_cq(*this, ctx),
 		recv_qp(*this, pd, recv_cq, srq),
-		src_mr(*this, pd, SZ()),
-		dst_mr(*this, pd, SZ())
+		src_mr(*this, pd, SZ(), 0x10),
+		dst_mr(*this, pd, SZ(), 0x10)
 	{ }
 
 	int SZ() { return GetParam(); }
 
 	void eager(int start, int length, uint64_t tag) {
-		EXEC(send_qp.send(src_mr.sge(start, length), tag, IBV_TM_OP_EAGER));
+		EXEC(send_qp.send(src_mr.sge(start, length), tag,
+				  IBV_WR_TAG_SEND_EAGER));
 
 		EXEC(send_cq.poll(1));
 		EXEC(srq_cq.poll(1));
@@ -370,30 +350,35 @@ struct tag_matching : public testing::TestWithParam<int>, public tag_matching_ba
 
 	void rndv(int start, int length, uint64_t tag) {
 		ibvt_mr fin(*this, pd, 0x20);
+		ibvt_mr hdr(*this, pd, 0);
 		fin.init();
 		EXEC(send_qp.recv(fin.sge(0, 0x20)));
-		EXEC(send_qp.rndv(src_mr.sge(start, length), tag));
+		EXEC(send_qp.rndv(src_mr.sge(start, length), tag, hdr));
 		EXEC(send_cq.poll(1));
 		EXEC(srq_cq.poll(1));
 	}
 
 	void append(int start, int length, uint64_t tag, int *idx = NULL) {
-		EXEC(srq.append(dst_mr, start, length, tag, idx));
+		EXEC(ctrl_qp.append(dst_mr, start, length, tag, idx));
+		EXEC(ctrl_cq.poll(1));
 		EXEC(srq_cq.poll(0));
 	}
 
 	void remove(int idx) {
-		EXEC(srq.remove(idx));
+		EXEC(ctrl_qp.remove(idx));
+		EXEC(ctrl_cq.poll(1));
 		EXEC(srq_cq.poll(0));
 	}
 
 	void recv(int start, int length) {
-		EXEC(srq.unexp(dst_mr, start, length));
+		EXEC(srq.recv(dst_mr, start, length));
 	}
 
 	virtual void SetUp() {
 		INIT(ctx.init());
 		INIT(srq.init());
+		INIT(ctrl_qp.init());
+		INIT(ctrl_qp.connect(&ctrl_qp));
 		INIT(send_qp.init());
 		INIT(recv_qp.init());
 		INIT(send_qp.connect(&recv_qp));
@@ -405,7 +390,6 @@ struct tag_matching : public testing::TestWithParam<int>, public tag_matching_ba
 	virtual void fix_uwq() {
 		for(int i = 0; i<33; i++)
 			EXEC(recv(0, SZ()));
-		phase_cnt = 0;
 	}
 
 	virtual void TearDown() {
@@ -418,8 +402,8 @@ TEST_P(tag_matching, e0_unexp) {
 	CHK_SUT(tag-matching);
 	EXEC(recv(0, SZ()));
 	EXEC(fix_uwq());
-	EXEC(eager(0, SZ(), 0x12345));
-	EXEC(dst_mr.check(0x10));
+	EXEC(eager(0x10, SZ()-0x10, 0x12345));
+	EXEC(dst_mr.check());
 }
 
 TEST_P(tag_matching, e1_match) {
@@ -427,15 +411,15 @@ TEST_P(tag_matching, e1_match) {
 	EXEC(fix_uwq());
 	EXEC(append(0, SZ(), 1));
 	EXEC(eager(0, SZ(), 1));
-	EXEC(dst_mr.check(0, 0x10));
+	EXEC(dst_mr.check());
 }
 
-#if 0
 TEST_P(tag_matching, u0_short) {
 	CHK_SUT(tag-matching);
 	EXEC(fix_uwq());
 	EXEC(append(0, SZ(), 1));
 	EXEC(send_qp.send(this->src_mr.sge(0, 0x40), 1,
+			  IBV_WR_TAG_SEND_EAGER,
 			  IBV_SEND_INLINE));
 
 	EXEC(send_cq.poll(1));
@@ -445,9 +429,11 @@ TEST_P(tag_matching, u0_short) {
 
 TEST_P(tag_matching, u2_rndv) {
 	CHK_SUT(tag-matching);
+	ibvt_mr hdr(*this, this->pd, 0x10);
+	EXECL(hdr.fill());
 	EXEC(fix_uwq());
 	EXEC(append(0, SZ(), 1));
-	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1));
+	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1, hdr));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 	EXEC(dst_mr.check());
@@ -455,8 +441,10 @@ TEST_P(tag_matching, u2_rndv) {
 
 TEST_P(tag_matching, u3_rndv_unexp) {
 	CHK_SUT(tag-matching);
+	ibvt_mr hdr(*this, this->pd, 0x10);
+	EXECL(hdr.fill());
 	EXEC(fix_uwq());
-	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1));
+	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1, hdr));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 	//EXEC(dst_mr.dump());
@@ -464,9 +452,11 @@ TEST_P(tag_matching, u3_rndv_unexp) {
 
 TEST_P(tag_matching, u4_rndv_sw) {
 	CHK_SUT(tag-matching);
+	ibvt_mr hdr(*this, this->pd, 0x10);
+	EXECL(hdr.fill());
 	EXEC(fix_uwq());
 	EXEC(append(0, SZ()/2, 1));
-	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1));
+	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1, hdr));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 	//EXEC(dst_mr.dump());
@@ -483,10 +473,13 @@ TEST_P(tag_matching, u1_imm) {
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 }
-#endif
+
+
+#undef N
+#define N 8
 
 TEST_P(tag_matching, e2_matchN) {
-	int i, N = std::min(SZ()/0x20, 8);
+	int i;
 	CHK_SUT(tag-matching);
 	EXEC(fix_uwq());
 	for (i=0; i<N; i++)
@@ -495,7 +488,7 @@ TEST_P(tag_matching, e2_matchN) {
 	for (i=0; i<N; i++)
 		EXEC(eager(SZ()/N*i, SZ()/N, i));
 	EXEC(eager(0, SZ(), 0x333));
-	EXEC(dst_mr.check(0, 0x10, N));
+	EXEC(dst_mr.check());
 }
 
 TEST_P(tag_matching, e3_remove) {
@@ -511,7 +504,7 @@ TEST_P(tag_matching, e3_remove) {
 	EXEC(append(SZ()/2, SZ()/2, 2));
 	EXEC(eager(SZ()/2, SZ()/2, 2));
 	EXEC(eager(0, SZ()/2, 1));
-	EXEC(dst_mr.check(0, 0x10, 2));
+	EXEC(dst_mr.check());
 }
 
 TEST_P(tag_matching, e4_repeat) {
@@ -520,29 +513,29 @@ TEST_P(tag_matching, e4_repeat) {
 	EXEC(fix_uwq());
 
 	EXEC(recv(0, SZ()));
-	EXEC(eager(0, SZ(), 5));
-	EXEC(dst_mr.check(0x10, 0));
+	EXEC(eager(0x10, SZ()-0x10, 5));
+	EXEC(dst_mr.check());
 
 	EXEC(append(0, SZ(), 5));
 	EXEC(eager(0, SZ(), 5));
-	EXEC(dst_mr.check(0, 0x10));
+	EXEC(dst_mr.check());
 
 	EXEC(recv(0, SZ()));
-	EXEC(eager(0, SZ(), 5));
-	EXEC(dst_mr.check(0x10, 0));
+	EXEC(eager(0x10, SZ()-0x10, 5));
+	EXEC(dst_mr.check());
 
 	EXEC(append(0, SZ(), 5));
 	EXEC(eager(0, SZ(), 5));
-	EXEC(dst_mr.check(0, 0x10));
+	EXEC(dst_mr.check());
 
 	EXEC(recv(0, SZ()));
-	EXEC(eager(0, SZ(), 5));
-	EXEC(dst_mr.check(0x10, 0));
+	EXEC(eager(0x10, SZ()-0x10, 5));
+	EXEC(dst_mr.check());
 }
 
 #undef N
-#define N 17
-#define R 15
+#define N 2
+#define R 1
 
 TEST_P(tag_matching, e5_mix) {
 	int i, idx[N], j, s;
@@ -560,11 +553,11 @@ TEST_P(tag_matching, e5_mix) {
 				EXEC(recv(0, SZ()));
 			}
 		for (i=s; i<N; i++) {
-			EXEC(eager(0, SZ(), i));
 			if (i&1)
-				EXEC(dst_mr.check(0x10, 0));
+				EXEC(eager(0x10, SZ()-0x10, i));
 			else
-				EXEC(dst_mr.check(0, 0x10));
+				EXEC(eager(0, SZ(), i));
+			EXEC(dst_mr.check());
 		}
 	}
 }
@@ -576,9 +569,10 @@ TEST_P(tag_matching, e6_unexp_inline) {
 
 	src.fill();
 	dst.init();
-	EXEC(srq.unexp(dst, 0, 0x20));
+	EXEC(srq.recv(dst, 0, 0x20));
 	EXEC(fix_uwq());
-	EXEC(send_qp.send(src.sge(0x10, 0x10), 0x12345, IBV_TM_OP_EAGER));
+	EXEC(send_qp.send(src.sge(0x10, 0x10), 0x12345,
+			  IBV_WR_TAG_SEND_EAGER));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 }
@@ -587,7 +581,8 @@ TEST_P(tag_matching, e7_no_tag) {
 	CHK_SUT(tag-matching);
 	EXEC(recv(0, SZ()));
 	EXEC(fix_uwq());
-	EXEC(send_qp.send(this->src_mr.sge(0, SZ()), 0, IBV_TM_OP_NO_TAG));
+	EXEC(send_qp.send(this->src_mr.sge(0x1, SZ()-0x1), 0,
+			  IBV_WR_TAG_SEND_NO_TAG));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 	EXEC(dst_mr.check());
@@ -604,21 +599,22 @@ TEST_P(tag_matching, e8_unexp_long) {
 		EXEC(recv(SZ() / n * i, SZ() / n));
 	EXEC(fix_uwq());
 	for(i = 0; i < n; i++)
-		EXEC(eager(SZ() / n * i,
-			   SZ() / n,
+		EXEC(eager(SZ() / n * i + 0x10,
+			   SZ() / n - 0x10,
 			   1ULL << i));
-	EXEC(dst_mr.check(0x10, 0, n));
+	EXEC(dst_mr.check());
 }
 
 TEST_P(tag_matching, r0_unexp) {
-	ibvt_mr dst(*this, this->pd, 0x80);
+	ibvt_mr dst(*this, this->pd, 0x80),
+		hdr(*this, this->pd, 0);
 
 	CHK_SUT(tag-matching);
 
 	dst.init();
-	EXEC(srq.unexp(dst, 0, 0x80));
+	EXEC(srq.recv(dst, 0, 0x80));
 	EXEC(fix_uwq());
-	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1));
+	EXEC(send_qp.rndv(this->src_mr.sge(0, SZ()), 1, hdr));
 	EXEC(send_cq.poll(1));
 	EXEC(srq_cq.poll(1));
 	//dst.dump();
@@ -629,7 +625,6 @@ TEST_P(tag_matching, r1_match) {
 	EXEC(fix_uwq());
 	EXEC(append(0, SZ(), 0x1234567890));
 	EXEC(rndv(0, SZ(), 0x1234567890));
-	//EXEC(dst_mr.dump());
 	EXEC(dst_mr.check());
 
 }

--- a/tests/vxlan/smoke.cc
+++ b/tests/vxlan/smoke.cc
@@ -251,7 +251,7 @@ struct ibvt_raw_qp : public ibvt_qp {
 
 	void set_up_flow_rules(
                 struct ibv_flow_attr **flow_rules) {
-
+#ifdef HAVE_VXLAN
         struct ibv_flow_spec* spec_info;
         struct ibv_flow_attr* attr_info;
 
@@ -387,6 +387,7 @@ struct ibvt_raw_qp : public ibvt_qp {
 		memset((void*)&spec_info->tcp_udp.mask.src_port, 0xFF,sizeof(spec_info->ipv4.mask.src_ip));
 
 	}
+#endif	
 }
 	
 	void send_raw_packet(void* buf,int match)


### PR DESCRIPTION
* Test huge pages ODP

* Fix ODP tests

fix hugetlb support detection
add ppc64 support

* Fix tag-matching tests

Add experimental (4.0) support.

* Fix check_port() method

* Fix vxlan & flow_tag compilation

* Adopt new tag-matching design

* Upstream compilation fixes